### PR TITLE
#25 메인 페이지에 섹션별 리스트 표시

### DIFF
--- a/src/entities/aladin/api/aladin.api.ts
+++ b/src/entities/aladin/api/aladin.api.ts
@@ -2,7 +2,6 @@
 
 import axios from "axios";
 import { Book } from "../model/aladin.interface";
-import { BookSectionItem } from "@/pages/home/model/home.interface";
 
 // NOTE: 알라딘 API 매뉴얼
 // https://docs.google.com/document/d/1mX-WxuoGs8Hy-QalhHcvuV17n50uGI2Sg_GHofgiePE/edit?tab=t.0
@@ -11,7 +10,7 @@ export const getItemList = async (
   categoryId: number,
   queryType = "Bestseller",
   size = 10,
-): Promise<BookSectionItem[]> => {
+): Promise<Book[]> => {
   try {
     const { data } = await axios.get(
       `http://www.aladin.co.kr/ttb/api/ItemList.aspx`,
@@ -89,7 +88,6 @@ export const getItemLookUp = async (isbn13: string): Promise<Book> => {
       },
     );
 
-    console.log(data?.item?.[0]);
     return data?.item?.[0];
   } catch (error) {
     console.error("Database Error:", error);

--- a/src/entities/aladin/api/aladin.api.ts
+++ b/src/entities/aladin/api/aladin.api.ts
@@ -2,6 +2,7 @@
 
 import axios from "axios";
 import { Book } from "../model/aladin.interface";
+import { BookSectionItem } from "@/pages/home/model/home.interface";
 
 // NOTE: 알라딘 API 매뉴얼
 // https://docs.google.com/document/d/1mX-WxuoGs8Hy-QalhHcvuV17n50uGI2Sg_GHofgiePE/edit?tab=t.0
@@ -9,7 +10,8 @@ import { Book } from "../model/aladin.interface";
 export const getItemList = async (
   categoryId: number,
   queryType = "Bestseller",
-): Promise<Book[]> => {
+  size = 10,
+): Promise<BookSectionItem[]> => {
   try {
     const { data } = await axios.get(
       `http://www.aladin.co.kr/ttb/api/ItemList.aspx`,
@@ -17,7 +19,7 @@ export const getItemList = async (
         params: {
           ttbkey: process.env.ALADIN_SERVICE_KEY,
           QueryType: queryType,
-          MaxResults: 100,
+          MaxResults: size,
           start: 1,
           SearchTarget: "Book",
           output: "js",
@@ -87,6 +89,7 @@ export const getItemLookUp = async (isbn13: string): Promise<Book> => {
       },
     );
 
+    console.log(data?.item?.[0]);
     return data?.item?.[0];
   } catch (error) {
     console.error("Database Error:", error);

--- a/src/entities/aladin/api/book.queries.ts
+++ b/src/entities/aladin/api/book.queries.ts
@@ -1,5 +1,6 @@
 import { queryOptions } from "@tanstack/react-query";
 import { getItemList, getItemSearch } from "./aladin.api";
+import { BookCardItem } from "@/pages/home/model/home.interface";
 
 export const aladinQueries = {
   all: () => ["books"] as const,
@@ -8,12 +9,28 @@ export const aladinQueries = {
     queryOptions({
       queryKey: [...aladinQueries.all(), "newItems"],
       queryFn: () => getItemList(351, "ItemNewSpecial"),
+      select(data): BookCardItem[] {
+        return data?.map((d) => ({
+          ...d,
+          thumbnail: d.cover,
+          reviewCount: 0,
+          averageRating: 0,
+        }));
+      },
     }),
 
   bestseller: () =>
     queryOptions({
       queryKey: [...aladinQueries.all(), "bestseller"],
       queryFn: () => getItemList(351, "Bestseller"),
+      select(data): BookCardItem[] {
+        return data?.map((d) => ({
+          ...d,
+          thumbnail: d.cover,
+          reviewCount: 0,
+          averageRating: 0,
+        }));
+      },
     }),
 
   byCategory: (categoryId: number, keyword: string) =>

--- a/src/entities/aladin/api/book.queries.ts
+++ b/src/entities/aladin/api/book.queries.ts
@@ -1,25 +1,31 @@
 import { queryOptions } from "@tanstack/react-query";
 import { getItemList, getItemSearch } from "./aladin.api";
 
-export const bookQueries = {
+export const aladinQueries = {
   all: () => ["books"] as const,
 
   newItems: () =>
     queryOptions({
-      queryKey: [...bookQueries.all(), "newItems"],
+      queryKey: [...aladinQueries.all(), "newItems"],
       queryFn: () => getItemList(351, "ItemNewSpecial"),
+    }),
+
+  bestseller: () =>
+    queryOptions({
+      queryKey: [...aladinQueries.all(), "bestseller"],
+      queryFn: () => getItemList(351, "Bestseller"),
     }),
 
   byCategory: (categoryId: number, keyword: string) =>
     queryOptions({
-      queryKey: [...bookQueries.all(), "category", categoryId],
-      queryFn: () => getItemList(categoryId),
+      queryKey: [...aladinQueries.all(), "category", categoryId],
+      queryFn: () => getItemList(categoryId, "Bestseller", 100),
       enabled: !keyword,
     }),
 
   search: (categoryId: number, keyword: string) =>
     queryOptions({
-      queryKey: [...bookQueries.all(), "search", categoryId, keyword],
+      queryKey: [...aladinQueries.all(), "search", categoryId, keyword],
       queryFn: () => getItemSearch(categoryId, keyword),
       enabled: !!keyword,
     }),

--- a/src/entities/aladin/index.ts
+++ b/src/entities/aladin/index.ts
@@ -1,3 +1,3 @@
 export * as aladinApi from "./api/aladin.api";
-export { bookQueries } from "./api/book.queries";
+export { aladinQueries } from "./api/book.queries";
 export type { Book } from "./model/aladin.interface";

--- a/src/entities/book/api/book.queries.ts
+++ b/src/entities/book/api/book.queries.ts
@@ -1,5 +1,10 @@
 import { queryOptions } from "@tanstack/react-query";
-import { fetchBook, fetchBooks } from "./get-book";
+import {
+  fetchBook,
+  fetchBooks,
+  mostAddedBooks,
+  popularBooks,
+} from "./get-book";
 
 export const bookQueries = {
   all: () => ["books"] as const,
@@ -14,5 +19,17 @@ export const bookQueries = {
     queryOptions({
       queryKey: [...bookQueries.all(), id],
       queryFn: () => fetchBook(id),
+    }),
+
+  popular: () =>
+    queryOptions({
+      queryKey: [...bookQueries.all(), "popular"],
+      queryFn: () => popularBooks(),
+    }),
+
+  mostAdded: () =>
+    queryOptions({
+      queryKey: [...bookQueries.all(), "mostAdded"],
+      queryFn: () => mostAddedBooks(),
     }),
 };

--- a/src/entities/book/api/get-book.ts
+++ b/src/entities/book/api/get-book.ts
@@ -1,5 +1,6 @@
 import axiosClient, { ssrAxiosClient } from "@/shared/axios";
 import { Book } from "../types";
+import { BookSectionItem } from "@/pages/home/model/home.interface";
 
 export const fetchBooks = async (keyword?: string): Promise<Book[]> => {
   try {
@@ -15,6 +16,28 @@ export const fetchBooks = async (keyword?: string): Promise<Book[]> => {
 export const fetchBook = async (id: number): Promise<Book> => {
   try {
     const { data } = await ssrAxiosClient.get(`books/${id}`);
+
+    return data;
+  } catch (error) {
+    console.error("Database Error:", error);
+    throw new Error("Failed to fetch data.");
+  }
+};
+
+export const popularBooks = async (): Promise<BookSectionItem[]> => {
+  try {
+    const { data } = await axiosClient.get(`books/popular`);
+
+    return data;
+  } catch (error) {
+    console.error("Database Error:", error);
+    throw new Error("Failed to fetch data.");
+  }
+};
+
+export const mostAddedBooks = async (): Promise<BookSectionItem[]> => {
+  try {
+    const { data } = await axiosClient.get(`books/most-added`);
 
     return data;
   } catch (error) {

--- a/src/entities/book/api/get-book.ts
+++ b/src/entities/book/api/get-book.ts
@@ -1,6 +1,5 @@
 import axiosClient, { ssrAxiosClient } from "@/shared/axios";
 import { Book } from "../types";
-import { BookSectionItem } from "@/pages/home/model/home.interface";
 
 export const fetchBooks = async (keyword?: string): Promise<Book[]> => {
   try {
@@ -24,7 +23,7 @@ export const fetchBook = async (id: number): Promise<Book> => {
   }
 };
 
-export const popularBooks = async (): Promise<BookSectionItem[]> => {
+export const popularBooks = async (): Promise<Book[]> => {
   try {
     const { data } = await axiosClient.get(`books/popular`);
 
@@ -35,7 +34,7 @@ export const popularBooks = async (): Promise<BookSectionItem[]> => {
   }
 };
 
-export const mostAddedBooks = async (): Promise<BookSectionItem[]> => {
+export const mostAddedBooks = async (): Promise<Book[]> => {
   try {
     const { data } = await axiosClient.get(`books/most-added`);
 

--- a/src/features/explore/book-filter/model/useBookFilter.ts
+++ b/src/features/explore/book-filter/model/useBookFilter.ts
@@ -1,4 +1,4 @@
-import { bookQueries } from "@/entities/aladin";
+import { aladinQueries } from "@/entities/aladin";
 import { useExploreStore } from "@/pages/explore/model/explore.store";
 import { useQuery } from "@tanstack/react-query";
 
@@ -6,11 +6,11 @@ export const useBookFilter = () => {
   const { category, keyword } = useExploreStore((state) => state);
 
   const { data: booksByCategory, isFetching: isCategoryFetching } = useQuery(
-    bookQueries.byCategory(category, keyword),
+    aladinQueries.byCategory(category, keyword),
   );
 
   const { data: booksBySearch, isFetching: isSearchFetching } = useQuery(
-    bookQueries.search(category, keyword),
+    aladinQueries.search(category, keyword),
   );
 
   return {

--- a/src/pages/explore/ui/book-card.tsx
+++ b/src/pages/explore/ui/book-card.tsx
@@ -2,17 +2,16 @@
 
 import Image from "next/image";
 import StarGroup from "@/shared/ui/star-group";
-import { Book } from "@/entities/aladin";
-import TagGroup from "../../../shared/ui/tag-group";
 
 import { validateSrc } from "@/shared/utils";
+import { BookSectionItem } from "@/pages/home/model/home.interface";
 
-export default function BookCard({ book }: { book: Book }) {
+export default function BookCard({ book }: { book: BookSectionItem }) {
   return (
     <>
       <div className="group flex cursor-pointer flex-col overflow-hidden rounded-lg border-gray-200 shadow-lg transition-transform duration-300 ease-in-out hover:-translate-y-2 hover:shadow-xl">
         <Image
-          src={validateSrc(book.cover)}
+          src={validateSrc(book?.thumbnail || book?.cover || "")}
           alt={book.title}
           width={150}
           height={150}
@@ -26,10 +25,9 @@ export default function BookCard({ book }: { book: Book }) {
             <TagGroup tags={book.tags} />
           </div> */}
           <div className="flex items-center justify-between">
-            <StarGroup rating={book.customerReviewRank} />
+            <StarGroup rating={book.averageRating} />
             <span className="text-xs text-gray-500">
-              0 reviews
-              {/* {book.reviewCount} reviews */}
+              {book.reviewCount} reviews
             </span>
           </div>
         </div>

--- a/src/pages/explore/ui/book-card.tsx
+++ b/src/pages/explore/ui/book-card.tsx
@@ -4,14 +4,20 @@ import Image from "next/image";
 import StarGroup from "@/shared/ui/star-group";
 
 import { validateSrc } from "@/shared/utils";
-import { BookSectionItem } from "@/pages/home/model/home.interface";
 
-export default function BookCard({ book }: { book: BookSectionItem }) {
+export interface BookCardItem {
+  title: string;
+  isbn: string;
+  averageRating: number;
+  thumbnail: string;
+  reviewCount: number;
+}
+export default function BookCard({ book }: { book: BookCardItem }) {
   return (
     <>
       <div className="group flex cursor-pointer flex-col overflow-hidden rounded-lg border-gray-200 shadow-lg transition-transform duration-300 ease-in-out hover:-translate-y-2 hover:shadow-xl">
         <Image
-          src={validateSrc(book?.thumbnail || book?.cover || "")}
+          src={validateSrc(book.thumbnail)}
           alt={book.title}
           width={150}
           height={150}

--- a/src/pages/explore/ui/book-list.tsx
+++ b/src/pages/explore/ui/book-list.tsx
@@ -28,7 +28,14 @@ export default function BookList() {
     <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
       {books?.map((book, index) => (
         <Link href={`${menus[0].href}/${book.isbn13}`} key={index}>
-          <BookCard book={book} />
+          <BookCard
+            book={{
+              ...book,
+              thumbnail: book.cover,
+              averageRating: 0,
+              reviewCount: 0,
+            }}
+          />
         </Link>
       ))}
     </div>

--- a/src/pages/home/model/home.interface.ts
+++ b/src/pages/home/model/home.interface.ts
@@ -1,11 +1,9 @@
-export interface BookSectionItem {
-  id: number;
+export interface BookCardItem {
   title: string;
   isbn: string;
   averageRating: number;
-  thumbnail?: string;
-  cover?: string;
+  thumbnail: string;
   reviewCount: number;
 }
 
-export type BookSectionList = BookSectionItem[] | undefined;
+export type BookSectionList = BookCardItem[] | undefined;

--- a/src/pages/home/model/home.interface.ts
+++ b/src/pages/home/model/home.interface.ts
@@ -1,0 +1,11 @@
+export interface BookSectionItem {
+  id: number;
+  title: string;
+  isbn: string;
+  averageRating: number;
+  thumbnail?: string;
+  cover?: string;
+  reviewCount: number;
+}
+
+export type BookSectionList = BookSectionItem[] | undefined;

--- a/src/pages/home/model/useSectionList.ts
+++ b/src/pages/home/model/useSectionList.ts
@@ -1,0 +1,17 @@
+import { aladinQueries } from "@/entities/aladin";
+import { bookQueries } from "@/entities/book/api";
+import { useQuery } from "@tanstack/react-query";
+
+export const useSectionList = () => {
+  const { data: newItems } = useQuery(aladinQueries.newItems());
+  const { data: bestseller } = useQuery(aladinQueries.bestseller());
+  const { data: popular } = useQuery(bookQueries.popular());
+  const { data: mostAdded } = useQuery(bookQueries.mostAdded());
+
+  return {
+    newItems,
+    bestseller,
+    popular,
+    mostAdded,
+  };
+};

--- a/src/pages/home/ui/book-list.tsx
+++ b/src/pages/home/ui/book-list.tsx
@@ -1,19 +1,20 @@
 "use client";
 
-import { bookQueries } from "@/entities/aladin";
 import BookCard from "@/pages/explore/ui/book-card";
 import { menus } from "@/widgets/layout-header";
-import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
 import React from "react";
+import { BookSectionList } from "../model/home.interface";
 
-export const BookList = () => {
-  const { data: books } = useQuery(bookQueries.newItems());
+interface BookListProps {
+  books: BookSectionList;
+}
 
+export const BookList = ({ books }: BookListProps) => {
   return (
     <>
       {books?.slice(0, 4).map((book) => (
-        <Link href={`${menus[0].href}/${book.isbn13}`} key={book.isbn13}>
+        <Link href={`${menus[0].href}/${book.isbn}`} key={book.isbn}>
           <BookCard book={book} />
         </Link>
       ))}

--- a/src/pages/home/ui/book-section.tsx
+++ b/src/pages/home/ui/book-section.tsx
@@ -1,0 +1,21 @@
+import React, { ReactNode } from "react";
+import { BookList } from "./book-list";
+import { BookSectionList } from "../model/home.interface";
+
+interface BookSectionProps {
+  title: ReactNode;
+  data: BookSectionList;
+}
+
+export const BookSection = ({ title, data }: BookSectionProps) => {
+  return (
+    <section className="flex w-full justify-center py-8">
+      <div className="container px-4 sm:px-0">
+        <h2 className="mb-8 text-2xl font-bold">{title}</h2>
+        <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4">
+          <BookList books={data} />
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/pages/home/ui/home-banner.tsx
+++ b/src/pages/home/ui/home-banner.tsx
@@ -1,0 +1,24 @@
+import { Button } from "@/shared/ui/button";
+import { menus } from "@/widgets/layout-header";
+import Link from "next/link";
+import React from "react";
+
+export const HomeBanner = () => {
+  return (
+    <section className="container relative flex h-[30vh] w-full items-center justify-center border-b">
+      <div className="space-y-4 text-center">
+        <h2 className="mb-4 text-xl font-bold text-[#333] sm:text-2xl">
+          좋은 책을 발견하고, 함께 나누세요!
+        </h2>
+        <p className="mb-8 text-base font-medium text-[#888] sm:text-base">
+          개발자들에게 추천하고 싶은 책이 있다면 리뷰를 남겨보세요.
+        </p>
+        <Link href={menus[0].href} className="block">
+          <Button size="lg" className="text-base font-semibold shadow-2xl">
+            책 탐험하기
+          </Button>
+        </Link>
+      </div>
+    </section>
+  );
+};

--- a/src/pages/home/ui/home-page.tsx
+++ b/src/pages/home/ui/home-page.tsx
@@ -1,55 +1,34 @@
-import { Button } from "@/shared/ui/button";
-import { menus } from "@/widgets/layout-header";
-import Link from "next/link";
-import { BookList } from "./book-list";
+"use client";
+
+import { InfoIcon } from "lucide-react";
+import { useSectionList } from "../model/useSectionList";
+import { BookSection } from "./book-section";
+import { HomeBanner } from "./home-banner";
 
 export function HomePage() {
+  const { newItems, bestseller, popular, mostAdded } = useSectionList();
+
   return (
     <>
-      {/* Hero Section */}
-      <section className="relative flex h-[60vh] w-full items-center justify-center">
-        <div className="text-center">
-          <h2 className="mb-4 text-3xl font-bold text-[#333] sm:text-5xl">
-            {/* 책을 읽고, 나만의 기록을 남겨보세요. */}
-            책, 그 너머를 향해
-          </h2>
-          <p className="mb-8 text-lg font-medium text-[#888] sm:text-2xl">
-            읽고 기록하고 나누세요.
-            <br />
-            당신의 기록이 또 다른 독서의 시작이 됩니다.
-          </p>
-          <Link href={menus[0].href}>
-            <Button size="lg" className="text-base font-semibold shadow-2xl">
-              책 탐험하기
-            </Button>
-          </Link>
-        </div>
-      </section>
+      <HomeBanner />
 
-      {/* Featured Books */}
-      <section className="flex w-full justify-center bg-gradient-to-t from-primary/10 to-primary/5 py-16">
-        <div className="container px-4 sm:px-0">
-          <h2 className="mb-8 text-3xl font-bold">지금, 이 책</h2>
-          <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4">
-            <BookList />
-          </div>
-        </div>
-      </section>
-
-      {/* User Login/Register CTA */}
-      <section className="flex h-[60vh] items-center bg-background py-16">
-        <div className="container text-center">
-          <h2 className="mb-4 text-3xl font-bold">우리와 함께해요!</h2>
-          <p className="mb-8 text-xl">로그인하고 다양한 기능을 즐겨보세요.</p>
-          <div className="space-x-4">
-            <Link href="/login">
-              <Button size="lg" className="shadow-lg">
-                Login
-              </Button>
-            </Link>
-          </div>
-        </div>
-      </section>
+      <div className="mb-8">
+        <BookSection title="인기 IT 책" data={popular} />
+        <BookSection title="이번 달 신간" data={newItems} />
+        <BookSection title="개발자가 많이 읽는 책" data={mostAdded} />
+        <BookSection
+          title={
+            <div className="flex items-end gap-1">
+              베스트셀러
+              <div className="flex items-center pb-0.5 text-gray-500">
+                <InfoIcon className="size-3" />
+                <span className="ml-0.5 text-sm font-normal">알라딘 제공</span>
+              </div>
+            </div>
+          }
+          data={bestseller}
+        />
+      </div>
     </>
   );
 }

--- a/src/pages/login/ui/login-page.tsx
+++ b/src/pages/login/ui/login-page.tsx
@@ -6,7 +6,7 @@ import { Logo } from "@/shared/ui/logo";
 export function LoginPage() {
   return (
     <div className="flex w-[400px] flex-col justify-center border-0 p-5">
-      <Link href="/explore">
+      <Link href="/">
         <h1 className="flex items-center justify-center gap-2 text-xl font-bold">
           <Logo />
           <span>IT Book Rating</span>

--- a/src/widgets/layout-header/ui/header.tsx
+++ b/src/widgets/layout-header/ui/header.tsx
@@ -8,7 +8,7 @@ export const Header = () => {
   return (
     <header className="container flex h-16 w-full items-center justify-between border-b">
       <div className="flex h-full items-center gap-5 md:gap-10">
-        <Link href="/explore">
+        <Link href="/">
           <h1 className="flex items-center gap-2 text-xl font-bold">
             <Logo />
             <span className="hidden lg:block">IT Book Rating</span>


### PR DESCRIPTION
### 📌 이번 PR에서 한 일
- [x] 메인 페이지에 섹션별 리스트 표시
- [x] 배너 타이틀 수정

### 🤔 고민/후회한 점
- 검색창을 상단에 넣고 싶은데 위치가 애매
- 메인페이지 카드 UI랑 explore의 UI가 겹치는데 디자인 다르게할지 고민

### 🛠 개선할 점
- 신간, 베스트셀러는 프론트에서 알라딘 API를 호출하는데, 백엔드에서 리뷰 데이터 종합해서 가져오도록 수정 필요

### ✅ 다음 PR에서 할 일
- [ ] 